### PR TITLE
FIX coffeescript-1.6.3

### DIFF
--- a/app/assets/javascripts/darwin/base.coffee
+++ b/app/assets/javascripts/darwin/base.coffee
@@ -71,5 +71,5 @@ class Darwin.Base
 
   trigger: ( event_name, params... ) ->
     if @_bound[ event_name ]
-      for own callback in @_bound[ event_name ]
+      for callback in @_bound[ event_name ]
         callback( params... )


### PR DESCRIPTION
`for ... in` loops does not allow anymore the use of `own`, which does
not serve any purpose anyway.

Close #3
