### PR TITLE
ADD global events

### DIFF
--- a/app/assets/javascripts/darwin.coffee
+++ b/app/assets/javascripts/darwin.coffee
@@ -4,6 +4,7 @@
 #= require './darwin/template'
 #= require './darwin/view'
 #= require './darwin/controller'
+#= require './darwin/events'
 #
 # Documentation is in /doc/introduction.md
 #

--- a/app/assets/javascripts/darwin/controller.coffee
+++ b/app/assets/javascripts/darwin/controller.coffee
@@ -18,7 +18,7 @@ class Darwin.Controller extends Darwin.Base
       @$root      = $( @root )
       @view       = new @options.View @$root
 
-      @bind_dom_events() unless exports?
+      @bind_events() unless exports?
       @view.run()
       @run() unless exports?
     else
@@ -28,44 +28,90 @@ class Darwin.Controller extends Darwin.Base
   run: ->
 
 
-  bind_dom_events: ->
-    @bind_dom_event( event, name ) for own name, event of @options.events
+  bind_events: ->
+    @bind_event( event, name ) for own name, event of @options.events
 
 
-  bind_dom_event: ( definition, name ) ->
+  bind_event: ( definition, name ) ->
     unless definition.el?
       throw new Error( "No el key for event : #{name or 'manually bound event'}" )
 
     unless definition.type?
       throw new Error( "No type key for event : #{name or 'manually bound event'}" )
 
+    [ method, method_name ] = @_find_method( definition )
 
-    wrap = ( callback, stop ) =>
-      ( event ) =>
-        unless ( window.crashed and @options.failsafe is true )
-          event.preventDefault() if stop
-          $target = $( event.target )
+    if definition.el is 'darwin'
+      @bind_global_event( definition, method, method_name )
+    else
+      @bind_dom_event( definition, method, method_name )
 
-          if definition.ensure_element isnt false
-            el = if definition.delegate? then definition.delegate else definition.el
-            
-            if el == 'root'
-              sel = 'root'
-            else
-              sel = ( @view.selectors[ el ] or @view._find_alternate_name( el ) )?.sel
 
-              if sel
-                $target = $target.parents( sel ).first() unless $target.is( sel )
-              else
-                $target = @view.get( el )
+  bind_global_event: ( definition, method, method_name ) ->
+    Darwin.on( definition.type, =>
+      unless window.crashed and @options.failsafe is true
+        method( arguments... )
+    )
 
-          args = [ $target, event ]
-          args.push arguments[i] for i in [1..(arguments.length - 1)] if arguments.length > 1
 
-          callback( args... )
-
+  bind_dom_event: ( definition, method, method_name ) ->
+    wrap = @_wrap_for_dom_element
     definition.stop = true if definition.type == 'click' and ! definition.stop?
+    $element = @view.get( definition.el )
 
+    if definition.delegate
+      delegate_to = @view.selectors[ definition.delegate ] or @view._find_alternate_name( definition.delegate )
+
+      if definition.cancel_delay and definition.cancel_delay > 0
+        callback = ( event ) =>
+          window.clearTimeout @[ '_' + method_name + '_timeout' ]
+          wrapped = wrap( method, definition )
+          @[ '_' + method_name + '_timeout' ] = window.setTimeout( ( -> ( wrapped event ) ), definition.cancel_delay )
+      else
+        callback = wrap method, definition
+
+      throw new Error "Selector not found : #{definition.delegate}" unless delegate_to
+      $element.delegate delegate_to.sel, definition.type, callback
+      @_dom_bound.push { el: $element, delegate: delegate_to.sel, type: definition.type, callback: callback }
+    else
+      if definition.cancel_delay and definition.cancel_delay > 0
+        callback = ( event ) =>
+          window.clearTimeout @[ '_' + method_name + '_timeout' ]
+          wrapped = wrap( method, definition )
+          @[ '_' + method_name + '_timeout' ] = window.setTimeout( ( -> ( wrapped event ) ), definition.cancel_delay )
+      else
+        callback = wrap method, definition
+
+      $element.bind definition.type, callback
+      @_dom_bound.push { el: $element, type: definition.type, callback: callback }
+
+
+  _wrap_for_dom_element: ( callback, definition ) =>
+    ( event ) =>
+      unless window.crashed and @options.failsafe is true
+        event.preventDefault() if definition.stop
+        $target = $( event.target )
+
+        if definition.ensure_element isnt false
+          el = if definition.delegate? then definition.delegate else definition.el
+          
+          if el == 'root'
+            sel = 'root'
+          else
+            sel = ( @view.selectors[ el ] or @view._find_alternate_name( el ) )?.sel
+
+            if sel
+              $target = $target.parents( sel ).first() unless $target.is( sel )
+            else
+              $target = @view.get( el )
+
+        args = [ $target, event ]
+        args.push arguments[i] for i in [1..(arguments.length - 1)] if arguments.length > 1
+
+        callback( args... )
+
+
+  _find_method: ( definition ) ->
     switch true
       when !! definition.controller_method
         method_name = definition.controller_method
@@ -88,34 +134,7 @@ class Darwin.Controller extends Darwin.Base
         else
           throw new Error( "Undefined method for controller : #{method_name}" )
 
-    $element = @view.get( definition.el )
-
-
-    if definition.delegate
-      delegate_to = @view.selectors[ definition.delegate ] or @view._find_alternate_name( definition.delegate )
-
-      if definition.cancel_delay and definition.cancel_delay > 0
-        callback = ( event ) =>
-          window.clearTimeout @[ '_' + method_name + '_timeout' ]
-          wrapped = wrap( method, definition.stop )
-          @[ '_' + method_name + '_timeout' ] = window.setTimeout( ( -> ( wrapped event ) ), definition.cancel_delay )
-      else
-        callback = wrap method, definition.stop
-
-      throw new Error "Selector not found : #{definition.delegate}" unless delegate_to
-      $element.delegate delegate_to.sel, definition.type, callback
-      @_dom_bound.push { el: $element, delegate: delegate_to.sel, type: definition.type, callback: callback }
-    else
-      if definition.cancel_delay and definition.cancel_delay > 0
-        callback = ( event ) =>
-          window.clearTimeout @[ '_' + method_name + '_timeout' ]
-          wrapped = wrap( method, definition.stop )
-          @[ '_' + method_name + '_timeout' ] = window.setTimeout( ( -> ( wrapped event ) ), definition.cancel_delay )
-      else
-        callback = wrap method, definition.stop
-
-      $element.bind definition.type, callback
-      @_dom_bound.push { el: $element, type: definition.type, callback: callback }
+    [ method, method_name ]
 
 
   destructor: ->

--- a/app/assets/javascripts/darwin/events.coffee
+++ b/app/assets/javascripts/darwin/events.coffee
@@ -1,0 +1,12 @@
+Darwin._events = {}
+
+Darwin.on = ( event_name, callback ) ->
+  Darwin._events[ event_name ] ?= []
+  Darwin._events[ event_name ].push( callback )
+  null
+
+Darwin.trigger = ( event_name, params... ) ->
+  if ( callbacks = Darwin._events[ event_name ] )
+    callback( params... ) for callback in callbacks
+
+  null

--- a/doc/controller.md
+++ b/doc/controller.md
@@ -250,6 +250,31 @@ You probably should use delegation to filter what you want
 more precisely, though.
 
 
+# Global events
+
+Sometime, you may want to allow modules to communicate with each others. How to
+achieve this ? 
+
+You could use `Darwin.controllers()` to retrieve foreign module and call one of
+its methods, but it would violate law of demeter.
+
+You could trigger an event on an element from other module, but now, you
+violate selector centralization.
+
+There's an other mean for that : you can use Darwin global events. To do so,
+trigger event like this :
+
+    Darwin.trigger( 'my_event_call' )
+
+
+The receiver can use special `darwin` element in its events declaration :
+
+    'Answer to global event': { el: 'darwin', type: 'my_event_call' }
+
+The usual controller event handling will apply then, calling a
+`darwin_my_event_called`, here.
+
+
 # Progressive enhancement and graceful degradation
 
 Like Darwin.View, Darwin.Controller has a `run()` and


### PR DESCRIPTION
Global events can be added that way :

```
Darwin.on( 'my_event_call', callback )
```

And can be triggered :

```
Darwin.trigger( 'my_event_call' )
```

This is integrated to Darwin.Controller, so you can use it in event
definition :

```
'Answer to global': { el: 'darwin', type: 'my_event_call' }
```

Now, in any other module, just trigger the event on darwin :

```
Darwin.trigger( 'my_event_call' )
```

This allows for modules to communicate without violating law of demeter
and selector centralization.
