### PR TITLE
ADD ability to load only modules in given nodes

### DIFF
--- a/app/assets/javascripts/darwin/loader.coffee
+++ b/app/assets/javascripts/darwin/loader.coffee
@@ -5,11 +5,13 @@ errors_got = 0
 
 loader = Darwin.Loader =
   run: ->
-    loader.module_roots().each( ( i, $module ) =>
+    loader.load_modules()
+
+  load_modules: ( $element = $ )
+    $element.find( '*[data-module]' ).each( ( i, $module ) =>
       $module = $( $module )
       loader.load_module( $module.attr( 'data-module' ), $module )
     )
-
 
   load_module: ( pathname, $root ) ->
     module_name = loader.compute_name( pathname )
@@ -24,11 +26,6 @@ loader = Darwin.Loader =
       throw new Error( "Can't find module #{pathname}" )
 
     controllers[ module_name ]
-
-
-  module_roots: ->
-    $( '*[data-module]' )
-
 
   compute_name: ( module_path ) ->
     name = module_path.replace( /\./g, '_' ).toLowerCase()

--- a/doc/loader.md
+++ b/doc/loader.md
@@ -41,12 +41,23 @@ is equivalent to :
 new App.Controllers.AdminArea.Users.Show( $( '#users' ) )
 ```
 
-To start, loader, add this in your application code :
+To start loader, add this in your application code :
 
 ```coffee
 Darwin.Loader.run()
 ```
 
+## Loading modules after DOM ready
+
+Darwin.Loader.run will be triggered on DOM ready. But what if you
+load some nodes on ajax that needs other modules ? You could run
+`Darwin.Loader.run()` again but that would reload already loaded
+modules.
+
+To load only modules inside a given node :
+```coffee
+Darwin.Loader.run( $element )
+```
 
 # Error handling
 


### PR DESCRIPTION
There is no method allowing to load modules defined only in a given part
of the DOM. This means if nodes are added through ajax, there is no esay
way to load modules for this brand new node.

Related #8

Details
- ADD method `Darwin.Loader.load_modules( $element )`
- UPDATE doc
