### PR TITLE
FIX custom arguments with delegate and cancel_delay

### DIFF
--- a/app/assets/javascripts/darwin/controller.coffee
+++ b/app/assets/javascripts/darwin/controller.coffee
@@ -66,7 +66,7 @@ class Darwin.Controller extends Darwin.Base
         callback = ( event ) =>
           window.clearTimeout $element.data( "_#{method_name}_timeout" )
           wrapped = wrap( method, definition )
-          $element.data( "_#{method_name}_timeout", window.setTimeout( ( -> ( wrapped event ) ), definition.cancel_delay ) )
+          $element.data( "_#{method_name}_timeout", window.setTimeout( ( -> ( wrapped arguments ) ), definition.cancel_delay ) )
       else
         callback = wrap method, definition
 
@@ -78,7 +78,7 @@ class Darwin.Controller extends Darwin.Base
         callback = ( event ) =>
           window.clearTimeout $element.data( "_#{method_name}_timeout" )
           wrapped = wrap( method, definition )
-          $element.data( "_#{method_name}_timeout", window.setTimeout( ( -> ( wrapped event ) ), definition.cancel_delay ) )
+          $element.data( "_#{method_name}_timeout", window.setTimeout( ( -> ( wrapped arguments ) ), definition.cancel_delay ) )
       else
         callback = wrap method, definition
 


### PR DESCRIPTION
When using `cancel_delay` or `delegate` in event declaration, it was not
possible anymore to pass custom parameters to event callback, like

```
$el.trigger( 'change', 'my_custom_param' )
```
